### PR TITLE
Multiline compact sequence/mapping/string

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -21,7 +21,7 @@ task 'build', 'build project', ->
             fs.mkdirSync libDir
         unless fs.existsSync libDir+'/Exception'
             fs.mkdirSync libDir+'/Exception'
-        toCompile = 'Yaml Utils Unescaper Pattern Parser Inline Escaper Dumper Exception/ParseException Exception/DumpException'.split ' '
+        toCompile = 'Yaml Utils Unescaper Pattern Parser Inline Escaper Dumper Exception/ParseException Exception/ParseMore Exception/DumpException'.split ' '
         do compileOne = ->
             name = toCompile.shift()
             outputDir = (if '/' in name then libDir+'/Exception' else libDir)
@@ -40,7 +40,7 @@ task 'build', 'build project', ->
             fs.mkdirSync libDebugDir
         unless fs.existsSync libDebugDir+'/Exception'
             fs.mkdirSync libDebugDir+'/Exception'
-        toCompile = 'Yaml Utils Unescaper Pattern Parser Inline Escaper Dumper Exception/ParseException Exception/DumpException'.split ' '
+        toCompile = 'Yaml Utils Unescaper Pattern Parser Inline Escaper Dumper Exception/ParseException Exception/ParseMore Exception/DumpException'.split ' '
         do compileOne = ->
             name = toCompile.shift()
             outputDir = (if '/' in name then libDebugDir+'/Exception' else libDebugDir)

--- a/src/Exception/ParseMore.coffee
+++ b/src/Exception/ParseMore.coffee
@@ -1,0 +1,12 @@
+
+class ParseMore extends Error
+
+    constructor: (@message, @parsedLine, @snippet) ->
+
+    toString: ->
+        if @parsedLine? and @snippet?
+            return '<ParseMore> ' + @message + ' (line ' + @parsedLine + ': \'' + @snippet + '\')'
+        else
+            return '<ParseMore> ' + @message
+
+module.exports = ParseMore

--- a/src/Inline.coffee
+++ b/src/Inline.coffee
@@ -4,6 +4,7 @@ Unescaper       = require './Unescaper'
 Escaper         = require './Escaper'
 Utils           = require './Utils'
 ParseException  = require './Exception/ParseException'
+ParseMore       = require './Exception/ParseMore'
 DumpException   = require './Exception/DumpException'
 
 # Inline YAML parsing and dumping
@@ -211,13 +212,13 @@ class Inline
     #
     # @return [String]  A YAML string
     #
-    # @throw [ParseException] When malformed inline YAML string is parsed
+    # @throw [ParseMore] When malformed inline YAML string is parsed
     #
     @parseQuotedScalar: (scalar, context) ->
         {i} = context
 
         unless match = @PATTERN_QUOTED_SCALAR.exec scalar[i..]
-            throw new ParseException 'Malformed inline YAML string ('+scalar[i..]+').'
+            throw new ParseMore 'Malformed inline YAML string ('+scalar[i..]+').'
 
         output = match[0].substr(1, match[0].length - 2)
 
@@ -239,7 +240,7 @@ class Inline
     #
     # @return [String]  A YAML string
     #
-    # @throw [ParseException] When malformed inline YAML string is parsed
+    # @throw [ParseMore] When malformed inline YAML string is parsed
     #
     @parseSequence: (sequence, context) ->
         output = []
@@ -282,7 +283,7 @@ class Inline
 
             ++i
 
-        throw new ParseException 'Malformed inline YAML string '+sequence
+        throw new ParseMore 'Malformed inline YAML string '+sequence
 
 
     # Parses a mapping to a YAML string.
@@ -292,7 +293,7 @@ class Inline
     #
     # @return [String]  A YAML string
     #
-    # @throw [ParseException] When malformed inline YAML string is parsed
+    # @throw [ParseMore] When malformed inline YAML string is parsed
     #
     @parseMapping: (mapping, context) ->
         output = {}
@@ -364,7 +365,7 @@ class Inline
                 if done
                     break
 
-        throw new ParseException 'Malformed inline YAML string '+mapping
+        throw new ParseMore 'Malformed inline YAML string '+mapping
 
 
     # Evaluates scalars and replaces magic values.


### PR DESCRIPTION
Fix following issues:
1) Multiline compact sequence/mapping/quoted string can begin without
indentation.
2) Unquoted string can extend to multiline with proper indentation.

Some examples:
![test](https://cloud.githubusercontent.com/assets/14190221/22852511/a8ff272a-f078-11e6-8fd1-c5af9acca60f.JPG)
