### PR TITLE
Fix: unable to parse end of the document marker (...)

### DIFF
--- a/src/Parser.coffee
+++ b/src/Parser.coffee
@@ -19,10 +19,10 @@ class Parser
     PATTERN_DECIMAL:                        new Pattern '\\d+'
     PATTERN_INDENT_SPACES:                  new Pattern '^ +'
     PATTERN_TRAILING_LINES:                 new Pattern '(\n*)$'
-    PATTERN_YAML_HEADER:                    new Pattern '^\\%YAML[: ][\\d\\.]+.*\n'
-    PATTERN_LEADING_COMMENTS:               new Pattern '^(\\#.*?\n)+'
-    PATTERN_DOCUMENT_MARKER_START:          new Pattern '^\\-\\-\\-.*?\n'
-    PATTERN_DOCUMENT_MARKER_END:            new Pattern '^\\.\\.\\.\\s*$'
+    PATTERN_YAML_HEADER:                    new Pattern '^\\%YAML[: ][\\d\\.]+.*\n', 'm'
+    PATTERN_LEADING_COMMENTS:               new Pattern '^(\\#.*?\n)+', 'm'
+    PATTERN_DOCUMENT_MARKER_START:          new Pattern '^\\-\\-\\-.*?\n', 'm'
+    PATTERN_DOCUMENT_MARKER_END:            new Pattern '^\\.\\.\\.\\s*$', 'm'
     PATTERN_FOLDED_SCALAR_BY_INDENTATION:   {}
 
     # Context types


### PR DESCRIPTION
In Regexp, '^' and '$' by default match the beginning and end of the
whole string rather than a single line. In Parser.parse(), each line is
a separate string, so this is fine. But in Parser.cleanup(), the whole
document is a single string. To allow '^' and '$' matching the beginning
and end of line in this string, we need modifier 'm' to make RegExp work
in multiline mode.